### PR TITLE
Swagger hub update

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,0 +1,15 @@
+name: swagger-update
+
+on: [push]
+
+jobs:
+  ubuntu-latest:
+    name: ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Push Swagger API to Swagger Hub
+        run: 'curl -X POST "https://api.swaggerhub.com/apis/buildingSMART/Documents-API" -H "Authorization: $SwaggerHubApiKey" -H "Content-Type: application/yaml" --data-binary @swagger.yaml'
+        env:
+            SwaggerHubApiKey: ${{ secrets.SWAGGER_HUB_API_KEY }}

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,6 +1,9 @@
 name: swagger-update
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   ubuntu-latest:


### PR DESCRIPTION
This PR adds a GitHub Action to automatically update the Swagger Hub API whenever we do a push to the `main` branch, closes #4.