### PR TITLE
Fix warnings and error in Swagger.yaml

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -154,6 +154,7 @@ paths:
         required: true
       responses:
         200:
+          description: ''
           content:
             application/json:
               schema:
@@ -199,7 +200,6 @@ components:
               type: boolean
               default: false
             multipart_form_data:
-              description: 'Please note, that if a server supplies custom data here to be used in multipart requests, it is very likely that the server will also have to set a custom Content-Type header with the multipart/form-data type and a server-provided boundary'
               $ref: '#/components/schemas/MultipartFormData'
             content_range_start:
               description: 'The inclusive, zero index based start for this part'
@@ -212,6 +212,7 @@ components:
     MultipartFormData:
       type: object
       additionalProperties: false
+      description: 'Please note, that if a server supplies custom data here to be used in multipart requests, it is very likely that the server will also have to set a custom Content-Type header with the multipart/form-data type and a server-provided boundary'
       required:
         - prefix
         - suffix


### PR DESCRIPTION
We've had these two issues show up on Swagger Hub:
![image](https://user-images.githubusercontent.com/10274404/167696391-6966fb12-57a2-4040-816e-4bc90420d9a4.png)


So, I added an empty `description` element to the bulk query endpoint (that's consistent with the other endpoints), and moved the description of a model from where it's referenced to the class itself.