### PR TITLE
Link public Swagger Hub API definition, closes #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Official repository by buildingSMART International](https://img.shields.io/badge/buildingSMART-Official%20Repository-orange.svg)](https://www.buildingsmart.org/)
 [![This repo is managed by the BCF Implementers Group](https://img.shields.io/badge/-BCF%20Implementers%20Group-blue.svg)](https://img.shields.io/badge/-BCF%20Implementers%20Group-blue.svg)
 
-[Swagger / OpenAPI Specification](./swagger.yaml). To view an interactive version of the Swagger specification, you can go to <https://editor.swagger.io/> and pase the content from the YAML file.
+[Swagger / OpenAPI Specification](./swagger.yaml). To view an interactive version of the Swagger specification, you can go to <[https://editor.swagger.io/](https://app.swaggerhub.com/apis/buildingSMART/Documents-API/1.0)> and pase the content from the YAML file.
 
 # Documents API
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Official repository by buildingSMART International](https://img.shields.io/badge/buildingSMART-Official%20Repository-orange.svg)](https://www.buildingsmart.org/)
 [![This repo is managed by the BCF Implementers Group](https://img.shields.io/badge/-BCF%20Implementers%20Group-blue.svg)](https://img.shields.io/badge/-BCF%20Implementers%20Group-blue.svg)
 
-[Swagger / OpenAPI Specification](./swagger.yaml). To view an interactive version of the Swagger specification, you can go to <[https://editor.swagger.io/](https://app.swaggerhub.com/apis/buildingSMART/Documents-API/1.0)> and pase the content from the YAML file.
+[Swagger / OpenAPI Specification](./swagger.yaml). To view an interactive version of the Swagger specification, you can go to [Swagger Hub](https://app.swaggerhub.com/apis/buildingSMART/Documents-API/1.0).
 
 # Documents API
 


### PR DESCRIPTION
Before closing, we need to publish the API in Swagger Hub so it's publicly available.